### PR TITLE
Upgrade MySQL dependency

### DIFF
--- a/synced_resources.gemspec
+++ b/synced_resources.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"
-  spec.add_development_dependency "mysql2", "~> 0.3.20"
+  spec.add_development_dependency "mysql2", "~> 0.4.9"
   spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
MariaDB is well-supported since 0.4.  Also, really no reason for not supporting MySQL < 0.4, I guess. @ronaldtse any reason why MySql dependency was constrained to "~> 0.3.20", disallowing versions from 0.4 onwards?