### PR TITLE
Fix rspec failures

### DIFF
--- a/lib/synced_resources.rb
+++ b/lib/synced_resources.rb
@@ -2,6 +2,7 @@
 #
 
 require 'inherited_resources'
+require 'responders'
 require 'synced_resources/engine'
 
 module SyncedResources

--- a/synced_resources.gemspec
+++ b/synced_resources.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "inherited_resources", "~> 1.7.1"
+  spec.add_dependency "responders"
   spec.add_dependency "rails", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
'inherited_resources' 1.7.0 requires 'responders' to work