### PR TITLE
Re-enable support for Rails 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in synced_resources.gemspec
 gemspec
+
+group :test do
+  gem "rails-controller-testing"
+end

--- a/gemfiles/Rails-5.0.gemfile
+++ b/gemfiles/Rails-5.0.gemfile
@@ -1,3 +1,7 @@
 eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
 
 gem "rails", "~> 5.0.0"
+
+group :test do
+  gem "rails-controller-testing"
+end

--- a/gemfiles/Rails-5.1.gemfile
+++ b/gemfiles/Rails-5.1.gemfile
@@ -1,3 +1,7 @@
 eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
 
 gem "rails", "~> 5.1.0"
+
+group :test do
+  gem "rails-controller-testing"
+end

--- a/gemfiles/Rails-head.gemfile
+++ b/gemfiles/Rails-head.gemfile
@@ -2,3 +2,7 @@ eval File.read "gemfiles/common.gemfile" # rubocop:disable Security/Eval
 
 gem "rails", github: "rails/rails"
 gem "arel", github: "rails/arel"
+
+group :test do
+  gem "rails-controller-testing", github: "rails/rails-controller-testing"
+end

--- a/lib/synced_resources.rb
+++ b/lib/synced_resources.rb
@@ -1,9 +1,9 @@
 # (c) Copyright 2017 Ribose Inc.
 #
 
-require "responders"
 require "action_view"
 require "inherited_resources"
+require "responders"
 require "synced_resources/engine"
 
 module SyncedResources

--- a/synced_resources.gemspec
+++ b/synced_resources.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "inherited_resources", "~> 1.7.1"
   spec.add_dependency "responders"
-  spec.add_dependency "rails", "~> 5.0"
+  spec.add_dependency "rails", ">= 4.0", "< 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "pry"

--- a/synced_resources.gemspec
+++ b/synced_resources.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "rubocop", "~> 0.49.1"


### PR DESCRIPTION
Rails 4.1+ is still required.

Fixes #12.