### PR TITLE
Remove #hide_action method calls

### DIFF
--- a/lib/synced_resources/view_helpers.rb
+++ b/lib/synced_resources/view_helpers.rb
@@ -14,7 +14,7 @@ module SyncedResources
           )
         end
         helper_method :view
-        hide_action :view
+        private :view
       end
     end
   end


### PR DESCRIPTION
The ActionController::HideActions module has been removed from Rails as of 5.0.  The #hide_action method wasn't very useful, though.  The effect was basically equivalent to making a method private.

See:
- https://github.com/elabs/pundit/pull/23#issuecomment-178441928
- https://github.com/rails/rails/issues/18336
- https://github.com/rails/rails/pull/18371
- #3