### PR TITLE
Prepare for Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ env:
   - DB_USER="travis" DB_NAME="synced_resources_test"
 
 before_install:
-  - gem install bundler -v 1.15.3
+  - gem install bundler -v 1.17.3
+
+install:
+  - bundle _1.17.3_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
 
 before_script:
   - mysql -e 'CREATE DATABASE $DB_NAME;'

--- a/synced_resources.gemspec
+++ b/synced_resources.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "responders"
   spec.add_dependency "rails", ">= 4.0", "< 6.0"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", ">= 1.15"
   spec.add_development_dependency "combustion"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Relax Bundler development dependency, so that 2.x is allowed.  However, use the latest 1.x in Travis CI for compatibility with Rails 4.